### PR TITLE
Ignore old title, summary, revisions if arc diff is create

### DIFF
--- a/src/workflow/ArcanistDiffWorkflow.php
+++ b/src/workflow/ArcanistDiffWorkflow.php
@@ -1971,11 +1971,12 @@ EOTEXT
 
     $repository_api = $this->getRepositoryAPI();
     $local = $repository_api->getLocalCommitInformation();
+    // This is already a create workflow. if local Title, summary and revisions are present, don't use those for create
     if ($local) {
       $result = $this->parseCommitMessagesIntoFields($local);
-      if ($this->getArgument('create')) {
-        unset($result[0]['revisionID']);
-      }
+      unset($result[0]['title']);
+      unset($result[0]['summary']);
+      unset($result[0]['revisionID']);
     }
 
     $result[0] = $this->dispatchWillBuildEvent($result[0]);


### PR DESCRIPTION
even though --create is not passed and the flow identified is create,…
 we need to unset title, summary and revisions for cleaner diffs